### PR TITLE
Fix note field printed twice for inproceedings entries

### DIFF
--- a/phys.bbx
+++ b/phys.bbx
@@ -329,8 +329,6 @@
   \newunit\newblock
   \usebibmacro{series+number}%
   \newunit\newblock
-  \printfield{note}%
-  \newunit\newblock
   \usebibmacro{organization+date}%
   \newunit\newblock
   \usebibmacro{chapter+pages}%


### PR DESCRIPTION
The `inproceedings` driver in `phys.bbx` emitted the `note` field twice, so citation counts appeared two times in the bibliography:

```
… Advanced Computing and Analysis Techniques in Physics Research, Vol. 1085, 432 citations (2018) … arXiv:1807.02876, 432 citations.
```

## Cause

`note` was printed at two positions in the driver:

1. The upstream biblatex-phys position, right after `series+number`
2. The trailing `\usebibmacro{note}` added to every driver so notes render at the end of an entry

When that trailing macro was introduced, the mid-driver `\printfield{note}` was removed from the `article`, `misc` and `report` drivers — but not from `inproceedings`, which kept both. Auditing every driver confirms `inproceedings` was the only one affected (`inbook` and `patent` still use the upstream position, but emit it only once).

## Fix

Drop the leftover `\printfield{note}` and its `\newunit\newblock`. Removing the separator alongside the field leaves exactly one `\newunit\newblock` between `series+number` and `organization+date`, so punctuation is unchanged.

## Verification

Rebuilt `cv_duarte_javier` — 27 pages, 0 LaTeX errors. All 15 starred entries now print their count exactly once, and the three `inproceedings` ones render consistently with the articles, at the end of the entry:

```
… arXiv:1807.02876, 432 citations.
```

| Entry | Type | Before | After |
|---|---|---|---|
| `Albertsson:2018maf` | inproceedings | ×2 | ×1 |
| `Banbury:2021mlperf` | inproceedings | ×2 | ×1 |
| `Fahim:2021cic` | inproceedings | ×2 | ×1 |
| 12 × `article` | article | ×1 | ×1 |

Note that counting occurrences in the extracted PDF text needs hyphenation rejoined first — `Banbury:2021mlperf` breaks across lines as `536 cita-\ntions` and a literal search misses it.

## Note for future upstream syncs

`phys.bbx` is vendored rather than pulled from TeX Live, so this edit persists — but a re-sync from upstream biblatex-phys will reintroduce the mid-driver `\printfield{note}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)